### PR TITLE
Add ROS guide to nav and languages page

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -48,6 +48,7 @@
                 <li><a href="/build-snaps/go">Go</a></li>
                 <li><a href="/build-snaps/python">Python</a></li>
                 <li><a href="/build-snaps/moos">MOOS</a></li>
+                <li><a href="/build-snaps/ros">ROS</a></li>
             </ul>
           </li>
           <li><a href="/build-snaps/syntax">Snapcraft syntax</a></li>

--- a/build-snaps/languages.md
+++ b/build-snaps/languages.md
@@ -22,5 +22,8 @@ Create snaps from your preferred programming language.
     <li class="inline-logos__item box">
       <a href="/build-snaps/moos"><img class="inline-logos__image" src="{{ site.asset_path }}04ff3e39-MOOSV-10-256.jpg" alt="MOOS" /><br />MOOS</a>
     </li>
+    <li class="inline-logos__item box">
+      <a href="/build-snaps/ros"><img class="inline-logos__image" src="{{ site.asset_path }}dc84f68e-c8749268-logo-ros.png" alt="ROS" /><br />ROS</a>
+    </li>
   </ul>
 </div>


### PR DESCRIPTION
Logo taken from the ROS press kit

![screenshot from 2017-10-10 17-34-51](https://user-images.githubusercontent.com/18480003/31395591-5e83235a-ade1-11e7-8c17-2cfa2beda8be.png)
