### PR TITLE
Update Fedora snapd to 2.28.5

### DIFF
--- a/core/install.md
+++ b/core/install.md
@@ -33,10 +33,10 @@ listed distributions.
 | Debian (testing)    | Supported   | 2.21    | _devmode_               |
 | Debian (unstable)   | Supported   | 2.21    | _devmode_               |
 | Fedora 24           | End of Life | 2.26.3  | _devmode_, _no-classic_ |
-| Fedora 25           | Supported   | 2.27.6  | _devmode_, _no-classic_ |
-| Fedora 26           | Supported   | 2.27.6  | _devmode_, _no-classic_ |
-| Fedora 27           | Supported   | 2.27.6  | _devmode_, _no-classic_ |
-| Fedora Rawhide      | Supported   | 2.27.6  | _devmode_, _no-classic_ |
+| Fedora 25           | Supported   | 2.28.5  | _devmode_, _no-classic_ |
+| Fedora 26           | Supported   | 2.28.5  | _devmode_, _no-classic_ |
+| Fedora 27           | Supported   | 2.28.5  | _devmode_, _no-classic_ |
+| Fedora Rawhide      | Supported   | 2.28.5  | _devmode_, _no-classic_ |
 | CentOS 7            | In progress | N/A     | _devmode_, _no-classic_ |
 | RHEL 7.3            | Unsupported | N/A     | N/A                     |
 | Arch Linux          | Outdated    | 2.21    | _devmode_, _no-classic_ |


### PR DESCRIPTION
The updates for Fedora 25, 26, and 27 have been marked to submit to stable and should roll out over the next day, with the exception of Fedora 27, which will be available as a zero-day update when Fedora 27 releases (the final freeze is in effect).