### PR TITLE
Remove duplicate languages entry

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -68,15 +68,6 @@
           </li>
           <li><a href="/build-snaps/publish">Publish your snap</a></li>
           <li><a href="/build-snaps/advanced-features">Advanced features</a></li>
-          <li>
-            <a href="/build-snaps/languages">Languages</a>
-            <ul>
-                <li><a href="/build-snaps/pre-built">Pre-built apps</a></li>
-                <li><a href="/build-snaps/node">Node</a></li>
-                <li><a href="/build-snaps/go">Go</a></li>
-                <li><a href="/build-snaps/python">Python</a></li>
-            </ul>
-          </li>
       </ul>
     </li>
     <li>


### PR DESCRIPTION
Languages was in the the navigation bar at the beginning and end of the build snaps section,
the entry at the end also has less items.

We want languages to be at the top and remove this unmaintained one.