### PR TITLE
Directly link to account creation

### DIFF
--- a/build-snaps/go.md
+++ b/build-snaps/go.md
@@ -254,7 +254,7 @@ sudo snap remove geth
 
 ## Share with your friends
 
-To share your snaps you need to publish them in the Snap Store. First, create an account on [dashboard.snapcraft.io](https://dashboard.snapcraft.io). Here you can customize how your snaps are presented, review your uploads and control publishing.
+To share your snaps you need to publish them in the Snap Store. First, create an account on [the dashboard](https://dashboard.snapcraft.io/openid/login/?next=/dev/snaps/). Here you can customize how your snaps are presented, review your uploads and control publishing.
 
 You’ll need to choose a unique “developer namespace” as part of the account creation process. This name will be visible by users and associated with your published snaps.
 

--- a/build-snaps/moos.md
+++ b/build-snaps/moos.md
@@ -174,7 +174,7 @@ sudo snap remove moos-ping
 
 ## Share with your friends
 
-To share your snaps you need to publish them in the Snap Store. First, create an account on [dashboard.snapcraft.io](https://dashboard.snapcraft.io). Here you can customize how your snaps are presented, review your uploads and control publishing.
+To share your snaps you need to publish them in the Snap Store. First, create an account on [the dashboard](https://dashboard.snapcraft.io/openid/login/?next=/dev/snaps/). Here you can customize how your snaps are presented, review your uploads and control publishing.
 
 You'll need to choose a unique "developer namespace" as part of the account creation process. This name will be visible by users and associated with your published snaps.
 

--- a/build-snaps/node.md
+++ b/build-snaps/node.md
@@ -138,7 +138,7 @@ sudo snap remove wethr
 
 ## Share with your friends
 
-To share your snaps you need to publish them in the Snap Store. First, create an account on [dashboard.snapcraft.io](https://dashboard.snapcraft.io). Here you can customize how your snaps are presented, review your uploads and control publishing.
+To share your snaps you need to publish them in the Snap Store. First, create an account on [the dashboard](https://dashboard.snapcraft.io/openid/login/?next=/dev/snaps/). Here you can customize how your snaps are presented, review your uploads and control publishing.
 
 You’ll need to choose a unique “developer namespace” as part of the account creation process. This name will be visible by users and associated with your published snaps.
 

--- a/build-snaps/pre-built.md
+++ b/build-snaps/pre-built.md
@@ -128,7 +128,7 @@ Removing the snap is simple too:
 
 ## Share with your friends
 
-To share your snaps you need to publish them in the Snap Store. First, create an account on [dashboard.snapcraft.io](https://dashboard.snapcraft.io). Here you can customize how your snaps are presented, review your uploads and control publishing.
+To share your snaps you need to publish them in the Snap Store. First, create an account on [the dashboard](https://dashboard.snapcraft.io/openid/login/?next=/dev/snaps/). Here you can customize how your snaps are presented, review your uploads and control publishing.
 
 You’ll need to choose a unique “developer namespace” as part of the account creation process. This name will be visible by users and associated with your published snaps.
 

--- a/build-snaps/publish.md
+++ b/build-snaps/publish.md
@@ -7,7 +7,7 @@ You can share your snaps with the world by publishing them to the Snap Store. Al
 
 ## 1. Create a Snap Store account
 
-To release snaps you will need to create an account on the [Snap Store dashboard](https://dashboard.snapcraft.io/). Here you can customize how your snaps are presented, review your uploads, and control the release process.
+To release snaps you will need to create an account on [the dashboard](https://dashboard.snapcraft.io/openid/login/?next=/dev/snaps/). Here you can customize how your snaps are presented, review your uploads, and control the release process.
 
 You'll need to choose a unique "developer namespace" as part of the account creation process. This name will be visible by users and associated with your snaps.
 

--- a/build-snaps/python.md
+++ b/build-snaps/python.md
@@ -191,7 +191,7 @@ Removing the snap is simple too:
 
 ## Share with your friends
 
-To share your snaps you need to publish them in the Snap Store. First, create an account on [dashboard.snapcraft.io](https://dashboard.snapcraft.io). Here you can customize how your snaps are presented, review your uploads and control publishing.
+To share your snaps you need to publish them in the Snap Store. First, create an account on [the dashboard](https://dashboard.snapcraft.io/openid/login/?next=/dev/snaps/). Here you can customize how your snaps are presented, review your uploads and control publishing.
 
 You’ll need to choose a unique “developer namespace” as part of the account creation process. This name will be visible by users and associated with your published snaps.
 

--- a/build-snaps/ros.md
+++ b/build-snaps/ros.md
@@ -168,7 +168,7 @@ sudo snap remove ros-talker-listener
 
 ## Share with your friends
 
-To share your snaps you need to publish them in the Snap Store. First, create an account on [dashboard.snapcraft.io](https://dashboard.snapcraft.io). Here you can customize how your snaps are presented, review your uploads and control publishing.
+To share your snaps you need to publish them in the Snap Store. First, create an account on [the dashboard](https://dashboard.snapcraft.io/openid/login/?next=/dev/snaps/). Here you can customize how your snaps are presented, review your uploads and control publishing.
 
 You'll need to choose a unique "developer namespace" as part of the account creation process. This name will be visible by users and associated with your published snaps.
 


### PR DESCRIPTION
Rather than make people hunt around on the homepage, we can directly link to the account creation page.