### PR TITLE
Add the recommendation to update apt before trying to install snapcraft

### DIFF
--- a/build-snaps/build-on-lxd-docker.md
+++ b/build-snaps/build-on-lxd-docker.md
@@ -27,12 +27,9 @@ Next, create an Ubuntu 16.04 container for building snaps. We'll assume your pro
        lxc launch ubuntu:16.04 snapcraft -c security.privileged=true
        lxc config device add snapcraft homedir disk source=/home/$USER path=/home/ubuntu
 
-After the previous step, you should update apt to get the latest information on all repositores. If you skip this step, apt may not find snapcraft if you try to install it:
-
-       lxc exec snapcraft -- apt update
-
 Finally, install snapcraft into the container:
 
+       lxc exec snapcraft -- apt update
        lxc exec snapcraft -- apt install snapcraft
 
 You're all set. Any time you want to build a snap, type the following command to run snapcraft relative to the current directory:

--- a/build-snaps/build-on-lxd-docker.md
+++ b/build-snaps/build-on-lxd-docker.md
@@ -27,6 +27,10 @@ Next, create an Ubuntu 16.04 container for building snaps. We'll assume your pro
        lxc launch ubuntu:16.04 snapcraft -c security.privileged=true
        lxc config device add snapcraft homedir disk source=/home/$USER path=/home/ubuntu
 
+After the previous step, you should update apt to get the latest information on all repositores. If you skip this step, apt may not find snapcraft if you try to install it:
+
+       lxc exec snapcraft -- apt update
+
 Finally, install snapcraft into the container:
 
        lxc exec snapcraft -- apt install snapcraft


### PR DESCRIPTION
When users installed and configured LXD, if apt install snapcraft command
is ran, apt will not find snapcraft because it needs to update first.

This PR fixes issue #186 as I proposed there and in the forums.