### PR TITLE
Update install-fedora.md

### DIFF
--- a/core/install-fedora.md
+++ b/core/install-fedora.md
@@ -10,18 +10,7 @@ You can install the snapd package with:
 
 ```
 sudo dnf install snapd
-```
-
-After that, everything is set up to get you started with snaps.
-
-### Note for Fedora 24 users
-
-Once the snapd package is successfully installed you have to
-enable the systemd unit which takes care of snapd's main
-communication socket as this is not automatically done:
-
-```
-sudo systemctl enable --now snapd.socket
+sudo ln -s /var/lib/snapd/snap /snap
 ```
 
 Now everything is set up to get you started with snaps.


### PR DESCRIPTION
Remove Fedora 24 text as it's out of support.
Add symlink creation to default install guide for Fedora.