### PR TITLE
Removing references to 'snap name registration'

### DIFF
--- a/build-snaps/register-snap.md
+++ b/build-snaps/register-snap.md
@@ -1,14 +1,14 @@
 ---
 layout: base
-title: Register a name for your snap
+title: Register your snap
 ---
 
 You can push your own version of a snap, provided you do so under a name you have rights to.
 
-New names can be registered by:
+New snaps can be registered by:
 
 * clicking **Register Snap** at the top of the [Snap Store dashboard](https://dashboard.snapcraft.io)
-* visiting: [the name registration page](https://dashboard.snapcraft.io/dev/snaps/register-name/)
+* visiting: [the snap registration page](https://dashboard.snapcraft.io/dev/snaps/register-snap/)
 * or running `snapcraft register <snap name>`
 
 ## Example
@@ -28,7 +28,7 @@ You are now the only developer able to use this name in the Snap Store. Note tha
 
 ## Name disputes
 
-If needed, snaps can be renamed to ensure they match the expectations of most users. If you're the developer or publisher most users expect for a snap name, you may claim it with the [snap name registration](https://dashboard.snapcraft.io/dev/snaps/register-name/) form.
+If needed, snaps can be renamed to ensure they match the expectations of most users. If you're the developer or publisher most users expect for a snap name, you may claim it with the [snap registration](https://dashboard.snapcraft.io/dev/snaps/register-snap/) form.
 
 ## What comes next?
 

--- a/build-snaps/register-snap.md
+++ b/build-snaps/register-snap.md
@@ -28,7 +28,7 @@ You are now the only developer able to use this name in the Snap Store. Note tha
 
 ## Name disputes
 
-If needed, snaps can be renamed to ensure they match the expectations of most users. If you're the developer or publisher most users expect for a snap name, you may claim it with the [snap registration](https://dashboard.snapcraft.io/dev/snaps/register-snap/) form.
+If needed, snaps can be renamed to ensure they match the expectations of most users. If you're the developer or publisher most users expect for a snap name, you may claim it with the [snap registration](https://dashboard.snapcraft.io/dev/snaps/register-name/) form.
 
 ## What comes next?
 


### PR DESCRIPTION
We are removing the references to registering a 'snap name' in favour of simply registering a 'snap'.