### PR TITLE
Fix a small mistake in "Getting started" section

### DIFF
--- a/build-snaps/c.md
+++ b/build-snaps/c.md
@@ -22,7 +22,7 @@ Typically this guide will take around 20 minutes and will result in a working C+
 
 # Getting started
 
-By way of an example, let’s take a look at how a C application can be snapped using snapcraft.
+By way of an example, let’s take a look at how a C++ application can be snapped using snapcraft.
 
 ## DOSBox Snap
 

--- a/build-snaps/python.md
+++ b/build-snaps/python.md
@@ -219,7 +219,7 @@ Be sure to update the `name:` in your `snapcraft.yaml` to match this registered 
 Use snapcraft to push the snap to the Snap Store.
 
 ```
-snapcraft push --release=edge mypthonsnap_*.snap
+snapcraft push --release=edge mypythonsnap_*.snap
 ```
 
 If you’re happy with the result, you can commit the snapcraft.yaml to your GitHub repo and [turn on automatic builds](https://build.snapcraft.io) so any further commits automatically get released to edge, without requiring you to manually build locally.


### PR DESCRIPTION
Fix a small mistake in "Getting started" section of /build-snaps/c tutorial.

See [issue #221](https://github.com/canonical-docs/snappy-docs/issues/221) for more details.