### PR TITLE
Update Geekbench version

### DIFF
--- a/build-snaps/pre-built.md
+++ b/build-snaps/pre-built.md
@@ -30,7 +30,7 @@ Snaps are defined in a single yaml file placed in the root of your project. The 
 
 ```yaml
 name: geekbench4
-version: 4.1.0
+version: 4.2.0
 summary: Cross-Platform Benchmark
 description: |
   Geekbench 4 measures your system's power and tells you whether your
@@ -43,7 +43,7 @@ confinement: devmode
 parts:
   geekbench4:
     plugin: dump
-    source: http://cdn.primatelabs.com/Geekbench-$SNAPCRAFT_PROJECT_VERSION-Linux.tar.gz
+    source: http://cdn.geekbench.com/Geekbench-$SNAPCRAFT_PROJECT_VERSION-Linux.tar.gz
 
 apps:
   geekbench4:
@@ -56,7 +56,7 @@ The `snapcraft.yaml` starts with a small amount of human-readable metadata, whic
 
 ```yaml
 name: geekbench4
-version: 4.1.0
+version: 4.2.0
 summary: Cross-Platform Benchmark
 description: |
   Geekbench 4 measures your system's power and tells you whether your
@@ -84,7 +84,7 @@ In this example we use the `$SNAPCRAFT_PROJECT_VERSION` variable derived from th
 parts:
   geekbench4:
     plugin: dump
-    source: http://cdn.primatelabs.com/Geekbench-$SNAPCRAFT_PROJECT_VERSION-Linux.tar.gz
+    source: http://cdn.geekbench.com/Geekbench-$SNAPCRAFT_PROJECT_VERSION-Linux.tar.gz
 ```
 
 #### Apps


### PR DESCRIPTION
Update Geekbench version from 4.1.0 to 4.2.0. Also, change the source server from cdn.primatelabs.com to cdn.geekbench.com.

This change matches the new snapcraft.yaml from [snapcraft-docs/geekbench4 repo](https://github.com/snapcraft-docs/geekbench4).