### PR TITLE
Change quotation marks

### DIFF
--- a/build-snaps/python.md
+++ b/build-snaps/python.md
@@ -187,7 +187,7 @@ The resulting snap can be installed locally. This requires the `--dangerous` fla
 
 Run the command:
 
-    youtube-dl “https://www.youtube.com/watch?v=k-laAxucmEQ”
+    youtube-dl "https://www.youtube.com/watch?v=k-laAxucmEQ"
 
 Removing the snap is simple too:
 


### PR DESCRIPTION
Change quotation marks to allow hassle-free copying and pasting. Before this change, youtube-dl crashed when trying to execute the copied command.