### PR TITLE
Fix a small mistake in "Getting started" section

### DIFF
--- a/build-snaps/c.md
+++ b/build-snaps/c.md
@@ -22,7 +22,7 @@ Typically this guide will take around 20 minutes and will result in a working C+
 
 # Getting started
 
-By way of an example, let’s take a look at how a C application can be snapped using snapcraft.
+By way of an example, let’s take a look at how a C++ application can be snapped using snapcraft.
 
 ## DOSBox Snap
 


### PR DESCRIPTION
Fix a small mistake in "Getting started" section of /build-snaps/c tutorial.

See [issue #221](https://github.com/canonical-docs/snappy-docs/issues/221) for more details.

I've created this pull request again because I messed up with my fork of this repo. Sorry for that!