### PR TITLE
Add missing colon

### DIFF
--- a/build-snaps/go.md
+++ b/build-snaps/go.md
@@ -119,7 +119,7 @@ The resulting snap can be installed locally. This requires the `--dangerous` fla
 sudo snap install httplab_*.snap --devmode --dangerous
 ```
 
-You can then try it out
+You can then try it out:
 
 ```
 httplab


### PR DESCRIPTION
Add missing colon in "go" snap creation tutorial.