### PR TITLE
Use same Snapcraft install command on all language tutorials

### DIFF
--- a/build-snaps/c.md
+++ b/build-snaps/c.md
@@ -122,7 +122,7 @@ If your application is intended to run as a service you simply add the line `dae
 
 You’ll first need to [install snap support](/core/install), and then install the snapcraft tool:
 ```
-sudo snap install --candidate --classic snapcraft
+sudo snap install snapcraft --classic
 ```
 
 If you have just installed snap support, start a new shell so your `PATH` is updated to include `/snap/bin`. You can then build this example yourself:

--- a/build-snaps/electron.md
+++ b/build-snaps/electron.md
@@ -87,7 +87,7 @@ The distribution target is then made to start the snap build. The `appId` must b
 
 You’ll first need to [install snap support](https://docs.snapcraft.io/core/install), and then install the snapcraft tool:
 ```
-sudo snap install --candidate --classic snapcraft
+sudo snap install snapcraft --classic
 ```
 
 To build Electron applications you also need Node installed, which can be downloaded from [NodeSource](https://github.com/nodesource/distributions).

--- a/build-snaps/go.md
+++ b/build-snaps/go.md
@@ -102,7 +102,7 @@ If your application is intended to run as a service you simply add the line `dae
 
 You’ll first need to [install snap support](/core/install), and then install the snapcraft tool:
 ```
-sudo snap install --beta --classic snapcraft
+sudo snap install snapcraft --classic
 ```
 
 If you have just installed snap support, start a new shell so your `PATH` is updated to include `/snap/bin`. You can then build this example yourself:

--- a/build-snaps/java.md
+++ b/build-snaps/java.md
@@ -129,7 +129,7 @@ If your application is intended to run as a service you simply add the line `dae
 
 You’ll first need to [install snap support](/core/install), and then install the snapcraft tool:
 ```
-sudo snap install --beta --classic snapcraft
+sudo snap install snapcraft --classic
 ```
 
 If you have just installed snap support, start a new shell so your `PATH` is updated to include `/snap/bin`. You can then build this example yourself:

--- a/build-snaps/moos.md
+++ b/build-snaps/moos.md
@@ -131,7 +131,7 @@ If your application is intended to run as a service you simply add the line `dae
 
 You’ll first need to [install snap support](/core/install), and then install the snapcraft tool:
 ```
-sudo snap install --beta --classic snapcraft
+sudo snap install snapcraft --classic
 ```
 
 If you have just installed snap support, start a new shell so your `PATH` is updated to include `/snap/bin`. You can then build this example yourself:

--- a/build-snaps/node.md
+++ b/build-snaps/node.md
@@ -111,7 +111,7 @@ If your application is intended to run as a service you simply add the line `dae
 
 You’ll first need to [install snap support](/core/install), and then install the snapcraft tool:
 ```
-sudo snap install --beta --classic snapcraft
+sudo snap install snapcraft --classic
 ```
 
 If you have just installed snap support, start a new shell so your `PATH` is updated to include `/snap/bin`. You can then build this example yourself:

--- a/build-snaps/pre-built.md
+++ b/build-snaps/pre-built.md
@@ -107,7 +107,7 @@ If your application is intended to run as a service you simply add the line `dae
 You’ll first need to [install snap support](/core/install), and then install the snapcraft tool:
 
 ```
-sudo snap install --beta --classic snapcraft
+sudo snap install snapcraft --classic
 ```
 
 If you have just installed snap support, start a new shell so your `PATH` is updated to include `/snap/bin`. You can then build this example yourself:

--- a/build-snaps/python.md
+++ b/build-snaps/python.md
@@ -104,7 +104,7 @@ If your application is intended to run as a service, add the line `daemon: simpl
 
 You’ll first need to [install snap support](/core/install), and then install the snapcraft tool:
 ```
-sudo snap install --beta --classic snapcraft
+sudo snap install snapcraft --classic
 ```
 
 If you have just installed snap support, start a new shell so your `PATH` is updated to include `/snap/bin`. You can then build this example yourself:

--- a/build-snaps/ros.md
+++ b/build-snaps/ros.md
@@ -107,7 +107,7 @@ If your application is intended to run as a service you simply add the line `dae
 
 You’ll first need to [install snap support](/core/install), and then install the snapcraft tool:
 ```
-sudo snap install --beta --classic snapcraft
+sudo snap install snapcraft --classic
 ```
 
 If you have just installed snap support, start a new shell so your `PATH` is updated to include `/snap/bin`. You can then build this example yourself:

--- a/build-snaps/ros2.md
+++ b/build-snaps/ros2.md
@@ -107,7 +107,7 @@ If your application is intended to run as a service you simply add the line `dae
 
 You’ll first need to [install snap support](/core/install), and then install the snapcraft tool:
 ```
-sudo snap install --candidate --classic snapcraft
+sudo snap install snapcraft --classic
 ```
 
 If you have just installed snap support, start a new shell so your `PATH` is updated to include `/snap/bin`. You can then build this example yourself:

--- a/build-snaps/ruby.md
+++ b/build-snaps/ruby.md
@@ -116,7 +116,7 @@ If your application is intended to run as a service you simply add the line `dae
 
 You’ll first need to [install snap support](/core/install), and then install the snapcraft tool:
 ```
-sudo snap install --candidate --classic snapcraft
+sudo snap install snapcraft --classic
 ```
 
 If you have just installed snap support, start a new shell so your `PATH` is updated to include `/snap/bin`. You can then build this example yourself:

--- a/build-snaps/rust.md
+++ b/build-snaps/rust.md
@@ -130,7 +130,7 @@ If your application is intended to run as a service you simply add the line `dae
 
 You'll first need to [install snap support](/core/install), and then install the snapcraft tool:
 ```
-sudo snap install --candidate --classic snapcraft
+sudo snap install snapcraft --classic
 ```
 
 If you have just installed snap support, start a new shell so your `PATH` is updated to include `/snap/bin`. You can then build this example yourself:


### PR DESCRIPTION
All language tutorials now use `sudo snap install snapcraft --classic` to install Snapcraft.

Fixes #245.