### PR TITLE
Trivial typo fix

### DIFF
--- a/core/install-debian.md
+++ b/core/install-debian.md
@@ -5,7 +5,7 @@ title: Install snapd on Debian
 
 On Debian snapd is available as part of the testing (currently 'stretch') and unstable ('sid') versions. It is currently not available in any stable version but will be soon.
 
-**Note:** Rasbian is currently not supported due to missing features in the kernel shipped.
+**Note:** Raspbian is currently not supported due to missing features in the kernel shipped.
 
 Generally you can install snapd on a Debian distribution via:
 


### PR DESCRIPTION
“Rasbian” → Ras**p**bian