### PR TITLE
Added store link to header navigation

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -53,6 +53,7 @@
                     </div>
                     {% assign current = page.url | downcase | split: '/' %}
                     <ul>
+                        <li><a href="https://snapcraft.io/store/">Store</a></li>
                         <li><a class="external" href="https://build.snapcraft.io">Build</a></li>
                         <li class='active'><a href="/">Docs</a></li>
                         <li><a class="external" href="https://tutorials.ubuntu.com">Tutorials</a></li>


### PR DESCRIPTION
## QA

- `./run`
- See the store link
- Click the store link
- Be the store link
- Celebrate