### PR TITLE
core/install-arch-linux: update notes on AUR, drop sudo in yaourt invocation

### DIFF
--- a/core/install-arch-linux.md
+++ b/core/install-arch-linux.md
@@ -3,11 +3,15 @@ layout: base
 title: Install snapd on Arch Linux
 ---
 
-snapd is available in the AUR (Arch User Repository) of Arch Linux. It can
-be installed via your favorite AUR helper (e.g. yaourt).
+snapd is available in the AUR (Arch User Repository) of Arch Linux. It can be
+installed via your favorite AUR helper (yaourt, pacaur, etc.) or by downloading
+the snapshot of build files manually from the
+[snapd](https://aur.archlinux.org/packages/snapd) AUR page.
+
+Run the following command to install the package using `yaourt` AUR helper:
 
 ```
-sudo yaourt -S snapd
+yaourt -S snapd
 ```
 
 Once installed the systemd unit which is responsible to manage the


### PR DESCRIPTION
The use of helpers for installing packages from AUR is a sensitive topic in
ArchLinux community. Officially none of the AUR helpers is blessed and the users
are 'expected' to inspect the build files themselves.

Rephrase the installation instructions for Arch so that we try to keep the
status quo.

Drop `sudo` from yaourt invocation as yaourt will run it itself just before
running pacman to install the built packages.. The way the helper is written,
it's best to avoid running it under sudo.
