### PR TITLE
Keep footer copyright date updated.

### DIFF
--- a/_includes/footer-legal.html
+++ b/_includes/footer-legal.html
@@ -1,4 +1,4 @@
-<p class="footer__text">&copy; 2017 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+<p class="footer__text">&copy; {{ site.time | date: '%Y' }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
 
 <ul class="footer__links">
     <li class="footer__list-item"><a href="http://www.ubuntu.com/legal">Legal information</a><span class="footer__dot"> &#183;</span></li>


### PR DESCRIPTION
The copyright date current is 2017. This updates it to 2018 and keeps it updated with Jekyll/Liquid.