### PR TITLE
Update snapcraft apt to snap

### DIFF
--- a/build-snaps/build-on-lxd-docker.md
+++ b/build-snaps/build-on-lxd-docker.md
@@ -15,9 +15,7 @@ Using LXD, you'll map your home directory (or wherever your projects live) into 
 
 First, install LXD:
 
-       sudo add-apt-repository ppa:ubuntu-lxc/lxd-stable
-       sudo apt update
-       sudo apt install lxd
+       sudo snap install lxd
        sudo lxd init
 
 Once installed, you can either log into a new shell, or run `newgrp lxd`.
@@ -29,8 +27,7 @@ Next, create an Ubuntu 16.04 container for building snaps. We'll assume your pro
 
 Finally, install snapcraft into the container:
 
-       lxc exec snapcraft -- apt update
-       lxc exec snapcraft -- apt install snapcraft
+       lxc exec snapcraft -- snap install snapcraft --classic
 
 You're all set. Any time you want to build a snap, type the following command to run snapcraft relative to the current directory:
 

--- a/build-snaps/index.md
+++ b/build-snaps/index.md
@@ -9,7 +9,7 @@ title: Build snaps
 
 `snapcraft` is the tool to create snaps. It's available on Ubuntu 16.04 LTS and above. To install it, simply run:
 
-    sudo apt install snapcraft
+    sudo snap install snapcraft --classic
 
 
 ## Build your first snap

--- a/build-snaps/index.md
+++ b/build-snaps/index.md
@@ -7,7 +7,7 @@ title: Build snaps
 
 ## Install snapcraft
 
-`snapcraft` is the tool to create snaps. It's available on Ubuntu 16.04 LTS and above. To install it, simply run:
+`snapcraft` is the tool to create snaps. To install it, [enable snap support](https://docs.snapcraft.io/core/install), then run:
 
     sudo snap install snapcraft --classic
 


### PR DESCRIPTION
Update the main docs to recommend people use snapcraft snap rather than the deb of snapcraft.