### PR TITLE
updated symbolic link for fedora

### DIFF
--- a/core/install-fedora.md
+++ b/core/install-fedora.md
@@ -10,7 +10,6 @@ You can install the snapd package with:
 
 ```
 sudo dnf install snapd
-sudo ln -s /usr/libexec/snapd /usr/lib/
 ```
 
 Now everything is set up to get you started with snaps.

--- a/core/install-fedora.md
+++ b/core/install-fedora.md
@@ -10,7 +10,7 @@ You can install the snapd package with:
 
 ```
 sudo dnf install snapd
-sudo ln -s /var/lib/snapd/snap /snap
+sudo ln -s /usr/libexec/snapd /usr/lib/
 ```
 
 Now everything is set up to get you started with snaps.


### PR DESCRIPTION
as per [bug 1536895](https://bugzilla.redhat.com/show_bug.cgi?id=1536895) this is the correct symbolic link to be able to run snap in fedora.
props to j.keuseman for the fix