### PR TITLE
New snapcraft branding

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -21,6 +21,9 @@
         </script>
 
         <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}Introducing snaps and commands to install and remove them on Ubuntu 16.04 LTS.{% endif %}">
+        
+        <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/fdc99abe-ico_16px.png" sizes="16x16" />
+        <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/0f3c662c-ico_32px.png" sizes="32x32" />
 
         <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.asset_path }}3361409d-apple-touch-icon-144x144-precomposed.png" />
         <link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ site.asset_path }}5fe4d3c8-apple-touch-icon-114x114-precomposed.png" />
@@ -43,7 +46,7 @@
                 </span>
                 <div class="logo">
                     <a href="https://snapcraft.io/">
-                        <img src="https://assets.ubuntu.com/v1/d45097a4-snapcraft.io-logotype.svg" alt="Snapcraft.io">
+                        <img src="https://assets.ubuntu.com/v1/ea4e7803-snapcraft_green-red_su_hex_cropped.svg" alt="Snapcraft.io">
                     </a>
                 </div>
                 <div id="nav">

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -46,7 +46,7 @@
                 </span>
                 <div class="logo">
                     <a href="https://snapcraft.io/">
-                        <img src="https://assets.ubuntu.com/v1/ea4e7803-snapcraft_green-red_su_hex_cropped.svg" alt="Snapcraft.io">
+                        <img src="https://assets.ubuntu.com/v1/2964e9eb-snapcraft-logo--web.svg" alt="Snapcraft.io">
                     </a>
                 </div>
                 <div id="nav">

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -25,7 +25,7 @@
     }
 
     img {
-      height: 28px;
+      height: 32px;
       display: block;
     }
   }


### PR DESCRIPTION
New logo and favicons

Fixes https://github.com/CanonicalLtd/snapcraft-design/issues/253

## QA

- `./run`
- Open in browser
- See branding
- Rejoice at it's majesty

## Screenshot
![snappy-docs-branding](https://user-images.githubusercontent.com/479384/35963991-55705c8e-0cae-11e8-92ce-5d0d2ecc9e39.jpg)
