### PR TITLE
core/{install,install-oe-yocto}: update package versions in Arch and Yocto, update Yocto instructions

### DIFF
--- a/core/install-oe-yocto.md
+++ b/core/install-oe-yocto.md
@@ -6,19 +6,20 @@ title: Install snapd on OpenEmbedded/Yocto
 As OpenEmbedded/Yocto is a meta distribution build system which doesn't provide
 you by default with any binary packages, we don't do this either for snapd.
 
-To allow inclusion of snapd in any Linux distribution built with OpenEmbedded/Yocto, a so called meta-layer [meta-snappy](https://github.com/morphis/meta-snappy/)
-exists which include all necessary recipes. These recipes cover required
-components and define dependencies on other dependencies outside of the
-meta-snappy layer.
+To allow inclusion of snapd in any Linux distribution built with
+OpenEmbedded/Yocto, a so called meta-layer
+[meta-snappy](https://github.com/morphis/meta-snappy/) exists which include all
+necessary recipes. These recipes cover required components and define
+dependencies on other dependencies outside of the meta-snappy layer.
 
 To keep things simple we only show here how you can include meta-snappy in a
-generic Yocto build targeting the QEMU emulator. More information about how
-to start with Yocto can be found [here](https://www.yoctoproject.org/2.2/yocto-project-qs/yocto-project-qs.html).
+generic Yocto build targeting the QEMU emulator. More information about how to
+start with Yocto can be found in the [Yocto Project Quick Start](https://www.yoctoproject.org/docs/2.4/yocto-project-qs/yocto-project-qs.html) manual.
 
-First, setup the Yocto build environment based on the 2.2 (morty) release:
+First, setup the Yocto build environment based on the 2.4 (rocko) release:
 
 ```
-git clone -b morty git://git.yoctoproject.org/poky
+git clone -b rocko git://git.yoctoproject.org/poky
 ```
 
 Now we need to add the meta-snappy layer into the build environment:
@@ -28,26 +29,38 @@ cd poky
 git clone https://github.com/morphis/meta-snappy.git
 ```
 
+Snaps are delivered as squashfs archive files. Support for squashfs is provided
+by meta-openembedded layer:
+
+```
+cd poky
+git clone -b rocko git://git.openembedded.org/meta-openembedded
+```
+
 After this we can start setting up the actual build environment:
 
 ```
 source oe-init-build-env
 ```
 
-Once that is done, we need to add the meta-snappy layer in the just created
-`conf/bblayers.conf` configuration file. Adjust the file to look like the following, but replace `/path/to` with the correct absolute path to the meta-snappy repository
-we just cloned:
+Once that is done, we need to add the meta-snappy and meta-openembedded layers
+in the just created `conf/bblayers.conf` configuration file. Adjust the file to
+look like the following, but replace `/path/to` with the correct absolute path
+to the repositories we just cloned:
 
 ```
 [...]
 BBLAYERS ?= " \
    ...
    /path/to/meta-snappy \
+   /path/to/meta-openembedded/meta-oe \
+   /path/to/meta-openembedded/meta-filesystems \
 "
 ```
 
-The last thing we need to do now before we can start a build is to adjust our
-`conf/local.conf` configuration file to enable a few features snapd depends on:
+Enable support for systemd which is mandatory for snapd. See the corresponding
+section in [Yocto Development Tasks Manual](https://www.yoctoproject.org/docs/latest/dev-manual/dev-manual.html#using-systemd-exclusively)
+for more details.
 
 ```
 cat << EOF >> conf/local.conf
@@ -56,6 +69,27 @@ VIRTUAL-RUNTIME_init_manager = "systemd"
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
 VIRTUAL-RUNTIME_initscripts = ""
 EOF
+```
+
+The `snap-confine` tool assumes that the home directory of `root` user is
+`/root`. Make sure we do not break this assumption, otherwise snaps mount
+namespace setup will fail early in the process. To use `/root', set `ROOT_HOME`
+like this:`
+
+```
+cat <<EOF >> conf/local.conf
+ROOT_HOME = "/root"
+EOF
+```
+
+(Optional) The build can take up a huge amount of disk space, inheriting
+`rm_work` class will help deal with that (see the [Yocto Reference Manual](https://www.yoctoproject.org/docs/latest/ref-manual/ref-manual.html#ref-classes-rm-work) for details). To remove unused 
+build files add the following to `conf/local.conf`:
+
+```
+INHERIT += "rm_work"
+# exclude snapd in case you want to develop snapd recipes
+RM_WORK_EXCLUDE += "snapd"
 ```
 
 That's it. Now we can start the build of the demo image the meta-snappy layer

--- a/core/install-oe-yocto.md
+++ b/core/install-oe-yocto.md
@@ -9,8 +9,8 @@ you by default with any binary packages, we don't do this either for snapd.
 To allow inclusion of snapd in any Linux distribution built with
 OpenEmbedded/Yocto, a so called meta-layer
 [meta-snappy](https://github.com/morphis/meta-snappy/) exists which include all
-necessary recipes. These recipes cover required components and define
-dependencies on other dependencies outside of the meta-snappy layer.
+necessary recipes. These recipes cover snapd components and define dependencies
+on the recipes and packages outside of the meta-snappy layer.
 
 To keep things simple we only show here how you can include meta-snappy in a
 generic Yocto build targeting the QEMU emulator. More information about how to
@@ -30,7 +30,7 @@ git clone https://github.com/morphis/meta-snappy.git
 ```
 
 Snaps are delivered as squashfs archive files. Support for squashfs is provided
-by meta-openembedded layer:
+by the meta-openembedded layer:
 
 ```
 cd poky
@@ -73,7 +73,7 @@ EOF
 
 The `snap-confine` tool assumes that the home directory of `root` user is
 `/root`. Make sure we do not break this assumption, otherwise snaps mount
-namespace setup will fail early in the process. To use `/root', set `ROOT_HOME`
+namespace setup will fail early in the process. To use `/root/', set `ROOT_HOME`
 like this:`
 
 ```

--- a/core/install-oe-yocto.md
+++ b/core/install-oe-yocto.md
@@ -73,8 +73,8 @@ EOF
 
 The `snap-confine` tool assumes that the home directory of `root` user is
 `/root`. Make sure we do not break this assumption, otherwise snaps mount
-namespace setup will fail early in the process. To use `/root/', set `ROOT_HOME`
-like this:`
+namespace setup will fail early in the process. To use `/root`, set `ROOT_HOME`
+like this:
 
 ```
 cat <<EOF >> conf/local.conf

--- a/core/install.md
+++ b/core/install.md
@@ -43,7 +43,7 @@ listed distributions.
 | Gentoo              | Outdated    | 2.15    | _devmode_               |
 | openSUSE Leap 42.2  | Unsupported | 2.23.5  | N/A                     |
 | openSUSE Tumbleweed | Unsupported | 2.23.5  | N/A                     |
-| Yocto               | Unsupported | 2.23.5  | _devmode_               |
+| Yocto 2.4           | Supported   | 2.31    | _devmode_               |
 
 _devmode_: confinement technology is not fully supported and all snaps are
 installed in [development mode](/reference/confinement).

--- a/core/install.md
+++ b/core/install.md
@@ -39,7 +39,7 @@ listed distributions.
 | Fedora Rawhide      | Supported   | 2.28.5  | _devmode_, _no-classic_ |
 | CentOS 7            | In progress | N/A     | _devmode_, _no-classic_ |
 | RHEL 7.3            | Unsupported | N/A     | N/A                     |
-| Arch Linux          | Outdated    | 2.30    | _devmode_, _no-classic_ |
+| Arch Linux          | Supported   | 2.31    | _devmode_, _no-classic_ |
 | Gentoo              | Outdated    | 2.15    | _devmode_               |
 | openSUSE Leap 42.2  | Unsupported | 2.23.5  | N/A                     |
 | openSUSE Tumbleweed | Unsupported | 2.23.5  | N/A                     |


### PR DESCRIPTION
Update packave versions in Arch and Yocto (note that a corresponding update to Yocto layer has not been merged yet: https://github.com/morphis/meta-snappy/pull/16).

Also, update Yocto instructions to be in sync (or at least closer) to what is already provided in the README file in meta-snappy layer.