### PR TITLE
Links to each tutorial from the relevant page

### DIFF
--- a/build-snaps/ci-integration.md
+++ b/build-snaps/ci-integration.md
@@ -16,9 +16,15 @@ Note that you should already have the following:
 - A [`.travis.yml`](https://docs.travis-ci.com/user/getting-started/) file in your project directory.
 - Travis [enabled for your repository](https://travis-ci.org/profile/) and configured to "build pushes."
 
+Travis does not currently allow open-source projects on [non-x86 architectures](https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments), or builds that take longer than [50 minutes](https://docs.travis-ci.com/user/customizing-the-build#Build-Timeouts). 
+
+## Using CircleCI
+
+- Tutorial: [Continuous snap delivery from CircleCI](https://tutorials.ubuntu.com/tutorial/continuous-snap-delivery-from-circle-ci)
+
 ## Using Launchpad
 
-Travis does not currently support open source projects building on [non-x86 architectures](https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments) or builds that take longer than [50 minutes](https://docs.travis-ci.com/user/customizing-the-build#Build-Timeouts). Launchpad can be set up as an alternative with no restrictions placed on build time and support for the following architectures:
+Launchpad has no restrictions on build time, and can build for these architectures:
  - AMD x86-64 (amd64)
  - ARM ARMv8 (arm64)
  - ARM ARMv7 Hard Float (armhf)

--- a/build-snaps/ci-integration.md
+++ b/build-snaps/ci-integration.md
@@ -18,6 +18,8 @@ Note that you should already have the following:
 
 Travis does not currently allow open-source projects on [non-x86 architectures](https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments), or builds that take longer than [50 minutes](https://docs.travis-ci.com/user/customizing-the-build#Build-Timeouts). 
 
+- Tutorial: [Continuous snap delivery from Travis CI](https://tutorials.ubuntu.com/tutorial/continuous-snap-delivery-from-travis-ci)
+
 ## Using CircleCI
 
 - Tutorial: [Continuous snap delivery from CircleCI](https://tutorials.ubuntu.com/tutorial/continuous-snap-delivery-from-circle-ci)

--- a/build-snaps/electron.md
+++ b/build-snaps/electron.md
@@ -5,7 +5,7 @@ title: Electron
 
 Snapcraft builds on top of the Electron desktop application framework to create snaps for people to install on Linux.
 
-# What problems do snaps solve for Electron applications?
+## What problems do snaps solve for Electron applications?
 
 Compared to Mac and Windows, distributing an Electron application for Linux and reaching the widest possible audience was complicated. How applications are packaged and delivered varies from distribution to distribution. With snapcraft it’s just one command to produce a bundle that works anywhere.
 
@@ -14,15 +14,15 @@ Here are some snap advantages that will benefit many Electron projects:
 * Simplify installation instructions, regardless of distribution, to `snap install myelectronapp`.
 * Directly control the delivery of automatic application updates.
 
-# How long will this guide take to complete?
+## How long will this guide take to complete?
 
 Typically this guide will take around 20 minutes and will result in a working Electron app in a snap. Once complete, you'll understand how to package Electron applications as snaps and deliver them to millions of Linux users. After making the snap available in the store, you'll get access to installation metrics and tools to directly manage the delivery of updates to Linux users. 
 
-# Getting started
+## Getting started
 
 By way of an example, let’s take a look at how a snap is created for the Electron Quickstart app.
 
-## Electron Quickstart
+### Electron Quickstart
 
 Using `electron-builder` and a few lines of additional configuration in the `package.json` file an Electron project can be adapted to produce snaps. We’ll break this down.
 
@@ -59,7 +59,7 @@ Using `electron-builder` and a few lines of additional configuration in the `pac
 }
 ```
 
-## Packaging for operating systems
+### Packaging for operating systems
 
 A distribution target (`dist`) needs to be added to the `scripts:` stanza to create package builds for Linux, Windows, and Mac.
 
@@ -70,7 +70,7 @@ A distribution target (`dist`) needs to be added to the `scripts:` stanza to cre
   },
 ```
 
-## Adding a snap package
+### Adding a snap package
 
 The distribution target is then made to start the snap build. The `appId` must be set, but is not used on Linux. Refer to the [Electron Builder documentation](https://www.electron.build/configuration/configuration) for an appropriate value if you are also building for Windows and Mac.
 
@@ -83,7 +83,7 @@ The distribution target is then made to start the snap build. The `appId` must b
   },
 ```
 
-## Building the snap
+### Building the snap
 
 You’ll first need to [install snap support](https://docs.snapcraft.io/core/install), and then install the snapcraft tool:
 ```
@@ -114,7 +114,7 @@ Removing the snap is simple too:
 sudo snap remove electron-quick-start
 ```
 
-## Share with your friends
+### Share with your friends
 
 To share your snaps you need to publish them in the Snap Store. First, create an account on [dashboard.snapcraft.io](https://dashboard.snapcraft.io/dev/account/). Here you can customize how your snaps are presented, review your uploads and control publishing.
 
@@ -126,7 +126,7 @@ Make sure the `snapcraft` command is authenticated using the email address attac
 snapcraft login
 ```
 
-### Reserve a name for your snap
+#### Reserve a name for your snap
 
 You can publish your own version of a snap, provided you do so under a name you have rights to. You can register a name on [dashboard.snapcraft.io](https://dashboard.snapcraft.io/register-snap/), or by running the following command:
 
@@ -136,7 +136,7 @@ snapcraft register myelectronsnap
 
 Be sure to update the `name:` in your `package.json` to match this registered name, then run `npm dist` again.
 
-### Upload your snap
+#### Upload your snap
 
 Use snapcraft to push the snap to the Snap Store.
 
@@ -153,3 +153,8 @@ Congratulations, you have an app in edge ready to share with other developers.
 
 Want to learn more? Continue on to learn how to get your app ready for a wider audience.
 -->
+
+## More information
+
+- Tutorial: [Snap a website with Electron](https://tutorials.ubuntu.com/tutorial/snap-a-website)
+- Video: [Easily distribute Electron apps via Snap](https://www.youtube.com/watch?v=xPtPiaHIghs) (37 minutes)

--- a/build-snaps/node.md
+++ b/build-snaps/node.md
@@ -221,3 +221,7 @@ Congratulations, you have an app in edge ready to share with other developers.
 
 Want to learn more? Continue on to learn how to get your app ready for a wider audience.
 -->
+
+## More information
+
+- Tutorial: [Build a nodejs service snap](https://tutorials.ubuntu.com/tutorial/build-a-nodejs-service)

--- a/build-snaps/python.md
+++ b/build-snaps/python.md
@@ -277,3 +277,7 @@ Congratulations, you have an app in edge ready to share with other developers.
 
 Want to learn more? Continue on to learn how to get your app ready for a wider audience.
 -->
+
+## More information
+
+- Tutorial: [Snap a Python application](https://tutorials.ubuntu.com/tutorial/snap-a-python-application)

--- a/core/index.md
+++ b/core/index.md
@@ -14,3 +14,8 @@ This section provides an overview to the key concepts and technologies that enab
 - [interfaces](/core/interfaces) to enable applications to access OS features or share features with other applications
 - [transactional updates](/core/updates) that enable snaps to be updated easily and rolled back if needed
 - [garbage collection](/core/versions) to ensure old versions of snaps are appropriately removed from devices
+
+## Tutorials
+
+- [Basic snap usage](https://tutorials.ubuntu.com/tutorial/basic-snap-usage)
+- [Advanced snap usage](https://tutorials.ubuntu.com/tutorial/advanced-snap-usage)


### PR DESCRIPTION
Someone can’t reasonably be expected to guess whether information on a particular detail of snaps and Snapcraft is provided as a document, a tutorial, a video, or more than one of these.

So, they’re more likely to find the information they want if it is organized by topic rather than by format. docs.snapcraft.io is already organized mostly by topic. So an easy way to organize _all_ the official information by topic is to link to information in other formats from the relevant docs.snapcraft.io page.

[The “Build your first snap” page](https://docs.snapcraft.io/build-snaps/your-first-snap) already does this, linking to a couple of relevant tutorials at the end. This change does the same for all the other snap-related tutorials currently published.

Adding the CircleCI tutorial requires small changes to the text so that it no longer implies Travis and Launchpad are the only two options. And adding the Electron tutorial involves fixing #303 (Heading hierarchy error on Electron page).