### PR TITLE
Tutorial links backURL params

### DIFF
--- a/build-snaps/ci-integration.md
+++ b/build-snaps/ci-integration.md
@@ -18,11 +18,11 @@ Note that you should already have the following:
 
 Travis does not currently allow open-source projects on [non-x86 architectures](https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments), or builds that take longer than [50 minutes](https://docs.travis-ci.com/user/customizing-the-build#Build-Timeouts). 
 
-- Tutorial: [Continuous snap delivery from Travis CI](https://tutorials.ubuntu.com/tutorial/continuous-snap-delivery-from-travis-ci)
+- Tutorial: [Continuous snap delivery from Travis CI](https://tutorials.ubuntu.com/tutorial/continuous-snap-delivery-from-travis-ci?backURL=https://docs.snapcraft.io/build-snaps/ci-integration)
 
 ## Using CircleCI
 
-- Tutorial: [Continuous snap delivery from CircleCI](https://tutorials.ubuntu.com/tutorial/continuous-snap-delivery-from-circle-ci)
+- Tutorial: [Continuous snap delivery from CircleCI](https://tutorials.ubuntu.com/tutorial/continuous-snap-delivery-from-circle-ci?backURL=https://docs.snapcraft.io/build-snaps/ci-integration)
 
 ## Using Launchpad
 

--- a/build-snaps/electron.md
+++ b/build-snaps/electron.md
@@ -156,5 +156,5 @@ Want to learn more? Continue on to learn how to get your app ready for a wider a
 
 ## More information
 
-- Tutorial: [Snap a website with Electron](https://tutorials.ubuntu.com/tutorial/snap-a-website)
+- Tutorial: [Snap a website with Electron](https://tutorials.ubuntu.com/tutorial/snap-a-website?backURL=https://docs.snapcraft.io/build-snaps/electron)
 - Video: [Easily distribute Electron apps via Snap](https://www.youtube.com/watch?v=xPtPiaHIghs) (37 minutes)

--- a/build-snaps/index.md
+++ b/build-snaps/index.md
@@ -35,6 +35,6 @@ The snapcraft source code provides snap demos for a [wide range of project types
 
 Recommended snap tutorials to get started:
 
-* [Basic snap usage](https://tutorials.ubuntu.com/tutorial/basic-snap-usage?utm_source=snapcraft.io&utm_medium=buildsnapsindex&utm_campaign=tutorials)
-* [Create your first snap](https://tutorials.ubuntu.com/tutorial/create-your-first-snap?utm_source=snapcraft.io&utm_medium=buildsnapsindex&utm_campaign=tutorials)
-* [Snap a nodejs service](https://tutorials.ubuntu.com/tutorial/build-a-nodejs-service?utm_source=snapcraft.io&utm_medium=buildsnapsindex&utm_campaign=tutorials)
+* [Basic snap usage](https://tutorials.ubuntu.com/tutorial/basic-snap-usage?backURL=https://docs.snapcraft.io/build-snaps/&utm_source=snapcraft.io&utm_medium=buildsnapsindex&utm_campaign=tutorials)
+* [Create your first snap](https://tutorials.ubuntu.com/tutorial/create-your-first-snap?backURL=https://docs.snapcraft.io/build-snaps/&utm_source=snapcraft.io&utm_medium=buildsnapsindex&utm_campaign=tutorials)
+* [Snap a nodejs service](https://tutorials.ubuntu.com/tutorial/build-a-nodejs-service?backURL=https://docs.snapcraft.io/build-snaps/&utm_source=snapcraft.io&utm_medium=buildsnapsindex&utm_campaign=tutorials)

--- a/build-snaps/metadata.md
+++ b/build-snaps/metadata.md
@@ -81,7 +81,7 @@ See the [apps and commands syntax](/build-snaps/syntax#apps-and-commands) for de
 
 ### Tutorial
 
-To get a first experience with snapping a service, the ["Build a nodejs service" tutorial](https://tutorials.ubuntu.com/tutorial/build-a-nodejs-service) will guide you through building, confining and general good practices to snap a simple web server.
+To get a first experience with snapping a service, the ["Build a nodejs service" tutorial](https://tutorials.ubuntu.com/tutorial/build-a-nodejs-service?backURL=https://docs.snapcraft.io/build-snaps/metadata) will guide you through building, confining and general good practices to snap a simple web server.
 
 ## Using wrappers
 

--- a/build-snaps/node.md
+++ b/build-snaps/node.md
@@ -224,4 +224,4 @@ Want to learn more? Continue on to learn how to get your app ready for a wider a
 
 ## More information
 
-- Tutorial: [Build a nodejs service snap](https://tutorials.ubuntu.com/tutorial/build-a-nodejs-service)
+- Tutorial: [Build a nodejs service snap](https://tutorials.ubuntu.com/tutorial/build-a-nodejs-service?backURL=https://docs.snapcraft.io/build-snaps/node)

--- a/build-snaps/python.md
+++ b/build-snaps/python.md
@@ -280,4 +280,4 @@ Want to learn more? Continue on to learn how to get your app ready for a wider a
 
 ## More information
 
-- Tutorial: [Snap a Python application](https://tutorials.ubuntu.com/tutorial/snap-a-python-application)
+- Tutorial: [Snap a Python application](https://tutorials.ubuntu.com/tutorial/snap-a-python-application?backURL=https://docs.snapcraft.io/build-snaps/python)

--- a/build-snaps/your-first-snap.md
+++ b/build-snaps/your-first-snap.md
@@ -203,6 +203,6 @@ will be recorded.
 
 Recommended snap tutorials to get started:
 
-* [Basic snap usage](https://tutorials.ubuntu.com/tutorial/basic-snap-usage?backURL=https://docs.snapcraft.io/build-snaps/your-first-snap&utm_source=snapcraft.io&utm_medium=buildfirstsnap&utm_campaign=tutorials)
-* [Create your first snap](https://tutorials.ubuntu.com/tutorial/create-your-first-snap?backURL=https://docs.snapcraft.io/build-snaps/your-first-snap&utm_source=snapcraft.io&utm_medium=buildfirstsnap&utm_campaign=tutorials)
-* [Snap a nodejs service](https://tutorials.ubuntu.com/tutorial/build-a-nodejs-service?backURL=https://docs.snapcraft.io/build-snaps/your-first-snap&utm_source=snapcraft.io&utm_medium=buildfirstsnap&utm_campaign=tutorials)
+* [Basic snap usage](https://tutorials.ubuntu.com/tutorial/basic-snap-usage?backURL=https://docs.snapcraft.io/build-snaps/your-first-snap)
+* [Create your first snap](https://tutorials.ubuntu.com/tutorial/create-your-first-snap?backURL=https://docs.snapcraft.io/build-snaps/your-first-snap)
+* [Snap a nodejs service](https://tutorials.ubuntu.com/tutorial/build-a-nodejs-service?backURL=https://docs.snapcraft.io/build-snaps/your-first-snap)

--- a/build-snaps/your-first-snap.md
+++ b/build-snaps/your-first-snap.md
@@ -203,6 +203,6 @@ will be recorded.
 
 Recommended snap tutorials to get started:
 
-* [Basic snap usage](https://tutorials.ubuntu.com/tutorial/basic-snap-usage?utm_source=snapcraft.io&utm_medium=buildfirstsnap&utm_campaign=tutorials)
-* [Create your first snap](https://tutorials.ubuntu.com/tutorial/create-your-first-snap?utm_source=snapcraft.io&utm_medium=buildfirstsnap&utm_campaign=tutorials)
-* [Snap a nodejs service](https://tutorials.ubuntu.com/tutorial/build-a-nodejs-service?utm_source=snapcraft.io&utm_medium=buildfirstsnap&utm_campaign=tutorials)
+* [Basic snap usage](https://tutorials.ubuntu.com/tutorial/basic-snap-usage?backURL=https://docs.snapcraft.io/build-snaps/your-first-snap&utm_source=snapcraft.io&utm_medium=buildfirstsnap&utm_campaign=tutorials)
+* [Create your first snap](https://tutorials.ubuntu.com/tutorial/create-your-first-snap?backURL=https://docs.snapcraft.io/build-snaps/your-first-snap&utm_source=snapcraft.io&utm_medium=buildfirstsnap&utm_campaign=tutorials)
+* [Snap a nodejs service](https://tutorials.ubuntu.com/tutorial/build-a-nodejs-service?backURL=https://docs.snapcraft.io/build-snaps/your-first-snap&utm_source=snapcraft.io&utm_medium=buildfirstsnap&utm_campaign=tutorials)

--- a/build-snaps/your-first-snap.md
+++ b/build-snaps/your-first-snap.md
@@ -205,6 +205,6 @@ will be recorded.
 
 Recommended snap tutorials to get started:
 
-* [Basic snap usage](https://tutorials.ubuntu.com/tutorial/basic-snap-usage)
-* [Create your first snap](https://tutorials.ubuntu.com/tutorial/create-your-first-snap)
+* [Basic snap usage](https://tutorials.ubuntu.com/tutorial/basic-snap-usage?backURL=https://docs.snapcraft.io/build-snaps/your-first-snap)
+* [Create your first snap](https://tutorials.ubuntu.com/tutorial/create-your-first-snap?backURL=https://docs.snapcraft.io/build-snaps/your-first-snap)
 

--- a/core/index.md
+++ b/core/index.md
@@ -17,5 +17,5 @@ This section provides an overview to the key concepts and technologies that enab
 
 ## Tutorials
 
-- [Basic snap usage](https://tutorials.ubuntu.com/tutorial/basic-snap-usage)
-- [Advanced snap usage](https://tutorials.ubuntu.com/tutorial/advanced-snap-usage)
+- [Basic snap usage](https://tutorials.ubuntu.com/tutorial/basic-snap-usage?backURL=https://docs.snapcraft.io/core/)
+- [Advanced snap usage](https://tutorials.ubuntu.com/tutorial/advanced-snap-usage?backURL=https://docs.snapcraft.io/core/)


### PR DESCRIPTION
# QA

- Pull the branch
- `./run`
- Visit:
 - http://localhost:8202/build-snaps/ci-integration/
 - http://localhost:8202/build-snaps/electron/
 - http://localhost:8202/build-snaps/
 - http://localhost:8202/build-snaps/metadata/
 - http://localhost:8202/build-snaps/node/
 - http://localhost:8202/build-snaps/python/
 - http://localhost:8202/build-snaps/your-first-snap/
 - http://localhost:8202/core/
- On each page click the tutorial link, followed by the back button - you should return to the page you were previously on.
- On each tutorial click through to the end, followed by the green tick at the end of the tutorial, this should bring you back to the docs page you were on before starting the tutorial.