### PR TITLE
Add warning to ensure guides are run on 16.04

### DIFF
--- a/build-snaps/c.md
+++ b/build-snaps/c.md
@@ -22,6 +22,8 @@ Typically this guide will take around 20 minutes and will result in a working C+
 
 # Getting started
 
+**Note:** We strongly recommend using an Ubuntu 16.04 host, VM or container for this guide. While it is possible to use newer releases of Ubuntu, or other Linux distributions, this may result in incorrect libraries being pulled into the build.
+
 By way of an example, let’s take a look at how a C++ application can be snapped using snapcraft.
 
 ## DOSBox Snap

--- a/build-snaps/electron.md
+++ b/build-snaps/electron.md
@@ -20,6 +20,8 @@ Typically this guide will take around 20 minutes and will result in a working El
 
 ## Getting started
 
+**Note:** We strongly recommend using an Ubuntu 16.04 host, VM or container for this guide. While it is possible to use newer releases of Ubuntu, or other Linux distributions, this may result in incorrect libraries being pulled into the build.
+
 By way of an example, let’s take a look at how a snap is created for the Electron Quickstart app.
 
 ### Electron Quickstart

--- a/build-snaps/go.md
+++ b/build-snaps/go.md
@@ -21,6 +21,8 @@ Typically this guide will take around 20 minutes and will result in a working Go
 
 ## Getting started
 
+**Note:** We strongly recommend using an Ubuntu 16.04 host, VM or container for this guide. While it is possible to use newer releases of Ubuntu, or other Linux distributions, this may result in incorrect libraries being pulled into the build.
+
 Let's take a look at httplab and go-ethereum by way of examples. Both are command line applications. httplab is a very simple example of a typical Go snap. go-ethereum (geth) requires a specific version of Go, and contains multiple commands.
 
 ### httplab

--- a/build-snaps/java.md
+++ b/build-snaps/java.md
@@ -20,6 +20,8 @@ Typically this guide will take around 20 minutes and will result in a working Ja
 
 # Getting started
 
+**Note:** We strongly recommend using an Ubuntu 16.04 host, VM or container for this guide. While it is possible to use newer releases of Ubuntu, or other Linux distributions, this may result in incorrect libraries being pulled into the build.
+
 By way of an example, let’s take a look at how a simple Java application can be snapped using snapcraft.
 
 ## FreePlane Snap

--- a/build-snaps/moos.md
+++ b/build-snaps/moos.md
@@ -18,6 +18,8 @@ Here are some snap advantages that will benefit many MOOS projects:
 
 ## Getting started
 
+**Note:** We strongly recommend using an Ubuntu 16.04 host, VM or container for this guide. While it is possible to use newer releases of Ubuntu, or other Linux distributions, this may result in incorrect libraries being pulled into the build.
+
 Let's take a look at the ping pong MOOS example application, and show how simple it is to snap.
 
 ### MOOS examples

--- a/build-snaps/node.md
+++ b/build-snaps/node.md
@@ -24,6 +24,8 @@ Typically this guide will take around 20 minutes and will result in a working No
 
 ## Getting started
 
+**Note:** We strongly recommend using an Ubuntu 16.04 host, VM or container for this guide. While it is possible to use newer releases of Ubuntu, or other Linux distributions, this may result in incorrect libraries being pulled into the build.
+
 By way of an example, let's take a look at how a snap is created for the wethr app.
 
 ### wethr

--- a/build-snaps/python.md
+++ b/build-snaps/python.md
@@ -22,6 +22,8 @@ Typically this guide will take around 20 minutes and will result in a working Py
 
 ## Getting started
 
+**Note:** We strongly recommend using an Ubuntu 16.04 host, VM or container for this guide. While it is possible to use newer releases of Ubuntu, or other Linux distributions, this may result in incorrect libraries being pulled into the build.
+
 Let's take a look at offlineimap and youtube-dl by way of examples. Both are command line applications. offlineimap uses Python 2 and only has Python module requirements. youtube-dl uses Python 3 and has system package requirements, in this case `ffmpeg`.
 
 ### offlineimap

--- a/build-snaps/ros.md
+++ b/build-snaps/ros.md
@@ -18,6 +18,8 @@ Here are some snap advantages that will benefit many ROS projects:
 
 ## Getting started
 
+**Note:** We strongly recommend using an Ubuntu 16.04 host, VM or container for this guide. While it is possible to use newer releases of Ubuntu, or other Linux distributions, this may result in incorrect libraries being pulled into the build.
+
 Let's take a look at the talker and listener out of the ROS tutorials, and show how simple that system is to snap.
 
 ### ROS Tutorials

--- a/build-snaps/ros2.md
+++ b/build-snaps/ros2.md
@@ -18,6 +18,8 @@ Here are some snap advantages that will benefit many ROS2 projects:
 
 ## Getting started
 
+**Note:** We strongly recommend using an Ubuntu 16.04 host, VM or container for this guide. While it is possible to use newer releases of Ubuntu, or other Linux distributions, this may result in incorrect libraries being pulled into the build.
+
 Let's take a look at a talker and listener out of the ROS2 examples, and show how simple that system is to snap.
 
 ### ROS2 Examples

--- a/build-snaps/ruby.md
+++ b/build-snaps/ruby.md
@@ -22,6 +22,8 @@ Typically this guide will take around 20 minutes and will result in a working Ru
 
 # Getting started
 
+**Note:** We strongly recommend using an Ubuntu 16.04 host, VM or container for this guide. While it is possible to use newer releases of Ubuntu, or other Linux distributions, this may result in incorrect libraries being pulled into the build.
+
 By way of an example, let's look at how a snap is created for the Travis CI app.
 
 ## Travis

--- a/build-snaps/rust.md
+++ b/build-snaps/rust.md
@@ -27,6 +27,8 @@ Typically this guide will take around 20 minutes and will result in a working Ru
 
 # Getting started
 
+**Note:** We strongly recommend using an Ubuntu 16.04 host, VM or container for this guide. While it is possible to use newer releases of Ubuntu, or other Linux distributions, this may result in incorrect libraries being pulled into the build.
+
 By way of an example, let's look at how a snap is created for the Parity app.
 
 ## Parity

--- a/build-snaps/your-first-snap.md
+++ b/build-snaps/your-first-snap.md
@@ -5,6 +5,8 @@ title: Build your first snap
 
 ## A single text file
 
+**Note:** We strongly recommend using an Ubuntu 16.04 host, VM or container for this guide. While it is possible to use newer releases of Ubuntu, or other Linux distributions, this may result in incorrect libraries being pulled into the build.
+
 Snapcraft uses a single text file to describe the entire build process for a snap: the `snapcraft.yaml` file.
 
 To get started with a template, you can run `snapcraft init`.


### PR DESCRIPTION
We've had a number of users run our tutorials on later versions of Ubuntu which resulted in newer libraries being pulled in, or snaps which don't work properly. This PR adds a warning to ensure people take care to run the tutorials on 16.04 host, vm or container. <3