### PR TITLE
Update nav to include new get started and remote parts docs

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -39,6 +39,7 @@
     <li>
       <a href="/build-snaps">Build snaps</a>
       <ul>
+          <li><a href="/build-snaps/get-started-snapcraft">Get started with snapcraft</a></li>
           <li><a href="/build-snaps/your-first-snap">Your first snap</a></li>
           <li>
             <a href="/build-snaps/languages">Languages</a>
@@ -58,7 +59,12 @@
             </ul>
           </li>
           <li><a href="/build-snaps/syntax">Snapcraft syntax</a></li>
-          <li><a href="/build-snaps/parts">Parts</a></li>
+          <li>
+            <a href="/build-snaps/parts">Parts</a>
+            <ul>
+              <li><a href="/build-snaps/remote-parts">Remote parts</a></li>
+            </ul>
+          </li>
           <li><a href="/build-snaps/plugins">Plugins</a></li>
           <li><a href="/build-snaps/scriptlets">Scriptlets</a></li>
           <li><a href="/build-snaps/hooks">Hooks</a></li>


### PR DESCRIPTION
Nav update to surface the latest doc additions:
- Get started with snapcraft
- Remote parts

![screenshot from 2018-03-05 15-06-50](https://user-images.githubusercontent.com/18480003/36979149-e4ed6618-2086-11e8-858f-ede6f0de7d42.png)
