### PR TITLE
Fedora symlink fix and explanation

### DIFF
--- a/core/install-fedora.md
+++ b/core/install-fedora.md
@@ -12,6 +12,12 @@ You can install the snapd package with:
 sudo dnf install snapd
 ```
 
+Snaps using `classic` confinement, such as code editors, also require a symlink from `/var/lib/snapd/snap` to `/snap`:
+
+```
+sudo ln -s /var/lib/snapd/snap /snap
+```
+
 Now everything is set up to get you started with snaps.
 
 ## Next Steps


### PR DESCRIPTION
Reintroducing the `/var/lib/snapd/snap` -> `/snap symlink` in Fedora install steps, since classic snaps [fail to install](https://bugzilla.redhat.com/attachment.cgi?id=1405194) without it.
