### PR TITLE
Copyedits versions.md

### DIFF
--- a/core/versions.md
+++ b/core/versions.md
@@ -1,26 +1,25 @@
 ---
 layout: base
-title: Multiple versions of snaps & garbage collection
+title: Multiple snap versions and garbage collection
 ---
 
-As a snap package is updated, the old version is kept. This enables a snapd system to rollback to an old, known to be good version of a snap if issues are detected in the updated snap. These old copies take up disk space, so garbage collection is performed automatically to ensure they don’t take up too much space, while preserving the ability to rollback snaps.
+When a snap package is updated, the old version is kept. This lets `snapd` roll back to a previous, known-good version if issues are detected in the new version.
 
-A snap present in a system can be:
+These old versions take up disk space, so garbage collection is performed automatically.
 
- - `installed` (but not enabled)
- - `enabled`
+## The update process
 
-When a snap is updated, the snap file for the latest version becomes the active snap file. The content from the previous snap version’s writeable areas (`SNAP_USER_DATA` and `SNAP_DATA`) are copied to a new location, for use by the updated snap.
+When a snap is updated, the latest version becomes the active snap file. The content from the previous snap version’s writeable areas (`SNAP_USER_DATA` and `SNAP_DATA`) are copied to a new location, for use by the updated snap.
 
 ![Garbage collection removes older snap files ](../media/garbage_collection.png)
 
-Garbage collection then removes and purges any snap files and their writeable areas for the snap versions prior to the one that has just been updated -- meaning that at most two versions of a snap will be present on the system. This saves disk space without compromising the ability to revert the snap to a previous known-good state.
+Garbage collection then removes and purges any snap files, and their writable areas, for snap versions prior to the one that has just been updated — meaning that, at most, two versions of a snap will be present on the system. This saves disk space without compromising the ability to revert the snap to a previous known-good state.
 
 Explicitly removing a snap from your system will also remove the code and purge the data for all prior versions.
 
 ## Example
 
-To illustrate the process take the example of installing and updating `hello-world` through a few versions. If you've version `1.0.1` installed, and do a `snap refresh` it downloads version `1.0.2`:
+To illustrate the process, take the example of installing and updating `hello-world` through a few versions. If you have version `1.0.1` installed, and do a `snap refresh` that downloads version `1.0.2`:
 
     $ sudo snap refresh
     64.00 KB / 64.00 KB [======================] 100.00 % 4.62 KB/s    
@@ -33,7 +32,7 @@ To illustrate the process take the example of installing and updating `hello-wor
     hello-world          1.0.1                 10   canonical  disabled
     hello-world          1.0.2                 29   canonical  -
 
-so, `1.0.2`, was downloaded and made active, leaving `1.0.1` installed. Doing the upgrade again:
+So, `1.0.2`, was downloaded and made active, leaving `1.0.1` installed. After a further update:
 
     $ sudo snap refresh
     64.00 KB / 64.00 KB [======================] 100.00 % 4.62 KB/s
@@ -44,4 +43,4 @@ so, `1.0.2`, was downloaded and made active, leaving `1.0.1` installed. Doing th
     hello-world          1.0.2                 29   canonical  disabled
     hello-world          1.0.3                 32   canonical  -
 
-and `1.0.1` is gone.
+`1.0.2` and `1.0.3` are now installed, and `1.0.1` is gone.


### PR DESCRIPTION
Mostly spelling and punctuation.

Removes the list of `installed` and `enabled` terms, because these terms aren’t then used anywhere in the page.