### PR TITLE
Basic syntax highlighting for YAML

### DIFF
--- a/_sass/_highlight.scss
+++ b/_sass/_highlight.scss
@@ -1,0 +1,357 @@
+.highlight .hll {
+  color:#595e62
+}
+
+.highlight .w,
+.highlight .whitespace {
+  color:#333
+}
+
+.highlight .esc,
+.highlight .escape {
+  color:#63a35c
+}
+
+.highlight .err,
+.highlight .error {
+  color:#333
+}
+
+.highlight .x,
+.highlight .other {
+  color:#333
+}
+
+.highlight .k,
+.highlight .keyword {
+  color:#a71d5d
+}
+
+.highlight .kc,
+.highlight .keyword-constant {
+  color:#0086b3
+}
+
+.highlight .kd,
+.highlight .keyword-declaration {
+  color:#a71d5d
+}
+
+.highlight .kn,
+.highlight .keyword-namespace {
+  color:#a71d5d
+}
+
+.highlight .kp,
+.highlight .keyword-pseudo {
+  color:#0086b3
+}
+
+.highlight .kr,
+.highlight .keyword-reserved {
+  color:#0086b3
+}
+
+.highlight .kt,
+.highlight .keyword-type {
+  color:#0086b3
+}
+
+.highlight .n,
+.highlight .name {
+  color:#333
+}
+
+.highlight .na,
+.highlight .name-attribute {
+  color:#795da3
+}
+
+.highlight .nb,
+.highlight .name.builtin {
+  color:#0086b3
+}
+
+.highlight .bp,
+.highlight .name-builtin-pseudo {
+  color:#ed6a43
+}
+
+.highlight .nc,
+.highlight .name-class {
+  color:#795da3
+}
+
+.highlight .no,
+.highlight .name-constant {
+  color:#0086b3
+}
+
+.highlight .nd,
+.highlight .name-decorator {
+  color:#333
+}
+
+.highlight .ni,
+.highlight .name-entity {
+  color:#0086b3
+}
+
+.highlight .ne,
+.highlight .name-exception {
+  color:#ed6a43
+}
+
+.highlight .nf,
+.highlight .name-function {
+  color:#333
+}
+
+.highlight .py,
+.highlight .name-property {
+  color:#ed6a43
+}
+
+.highlight .nl,
+.highlight .name-label {
+  color:#0086b3
+}
+
+.highlight .nn,
+.highlight .name-namespace {
+  color:#333
+}
+
+.highlight .nx,
+.highlight .name-other {
+  color:#795da3
+}
+
+.highlight .nt,
+.highlight .name-tag {
+  color:#63a35c
+}
+
+.highlight .nv,
+.highlight .name-variable {
+  color:#183691
+}
+
+.highlight .vc,
+.highlight .name-variable-class {
+  color:#ed6a43
+}
+
+.highlight .vg,
+.highlight .name-variable-global {
+  color:#ed6a43
+}
+
+.highlight .vi,
+.highlight .name-variable-instance {
+  color:#ed6a43
+}
+
+.highlight .l,
+.highlight .literal {
+  color:#63a35c
+}
+
+.highlight .ld,
+.highlight .literal-date {
+  color:#795da3
+}
+
+.highlight .s,
+.highlight .string {
+  color:#183691
+}
+
+.highlight .sb,
+.highlight .string-backtick {
+  color:#595e62
+}
+
+.highlight .sc,
+.highlight .string-char {
+  color:#183691
+}
+
+.highlight .sd,
+.highlight .string-doc {
+  color:#183691
+}
+
+.highlight .s2,
+.highlight .string-double {
+  color:#183691
+}
+
+.highlight .se,
+.highlight .string-escape {
+  color:#183691
+}
+
+.highlight .sh,
+.highlight .string-heredoc {
+  color:#183691
+}
+
+.highlight .si,
+.highlight .string-interpol {
+  color:#183691
+}
+
+.highlight .sx,
+.highlight .string-other {
+  color:#183691
+}
+
+.highlight .sr,
+.highlight .string-regex {
+  color:#183691
+}
+
+.highlight .s1,
+.highlight .string-single {
+  color:#183691
+}
+
+.highlight .ss,
+.highlight .string-symbol {
+  color:#a71d5d
+}
+
+.highlight .m,
+.highlight .number {
+  color:#0086b3
+}
+
+.highlight .mb,
+.highlight .number-bin {
+  color:#0086b3
+}
+
+.highlight .mf,
+.highlight .number-float {
+  color:#0086b3
+}
+
+.highlight .mh,
+.highlight .number-hex {
+  color:#0086b3
+}
+
+.highlight .mi,
+.highlight .number-integer {
+  color:#0086b3
+}
+
+.highlight .il,
+.highlight .number-integer-long {
+  color:#0086b3
+}
+
+.highlight .mo,
+.highlight .number-oct {
+  color:#0086b3
+}
+
+.highlight .o,
+.highlight .operator {
+  color:#333
+}
+
+.highlight .ow,
+.highlight .operator-word {
+  color:#a71d5d
+}
+
+.highlight .p,
+.highlight .punctuation {
+  color:#183691
+}
+
+.highlight .c,
+.highlight .comment {
+  color:#595e62
+}
+
+.highlight .cm,
+.highlight .comment-multiline {
+  color:#595e62
+}
+
+.highlight .cp,
+.highlight .comment-preproc {
+  font-weight:bold;
+  color:#1d3e81
+}
+
+.highlight .c1,
+.highlight .comment-single {
+  color:#595e62
+}
+
+.highlight .cs,
+.highlight .comment-special {
+  color:#595e62
+}
+
+.highlight .g,
+.highlight .generic {
+  color:#0086b3
+}
+
+.highlight .gd,
+.highlight .generic-deleted {
+  color:#bd2c00;
+  background-color:#ffecec
+}
+
+.highlight .ge,
+.highlight .generic-emph {
+  color:#b52a1d
+}
+
+.highlight .gr,
+.highlight .generic-error {
+  color:#b52a1d
+}
+
+.highlight .gh,
+.highlight .generic-heading {
+  font-weight:bold;
+  color:#1d3e81
+}
+
+.highlight .gi,
+.highlight .generic-inserted {
+  color:#55a532;
+  background-color:#eaffea
+}
+
+.highlight .go,
+.highlight .generic-output {
+  color:#333
+}
+
+.highlight .gp,
+.highlight .generic-prompt {
+  color:#333
+}
+
+.highlight .gs,
+.highlight .generic-strong {
+  color:#333
+}
+
+.highlight .gu,
+.highlight .generic-subheading {
+  font-weight:bold,#1d3e81
+}
+
+.highlight .gt,
+.highlight .generic-traceback {
+  color:#333
+}

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -19,6 +19,7 @@ $color-link:       #007aa6;
 @import "header";
 @import "documentation";
 @import "inline-logos";
+@import "highlight";
 @import "footer";
 
 @import "command-line";


### PR DESCRIPTION
# Done

Fixes https://github.com/canonical-docs/snappy-docs/issues/370.

- Added basic syntax highlighting based on the MAAS docs.

This is a temporary solution until (Convert repository to documentation-builder format)[https://github.com/CanonicalLtd/snappy-design-squad/issues/389] has been implemented

# QA

- Pull this branch
- `./run`
- Visit http://0.0.0.0:8202/build-snaps/python see syntax highlighting for the YAML.