### PR TITLE
Updated bug tracking links

### DIFF
--- a/_includes/footer-legal.html
+++ b/_includes/footer-legal.html
@@ -13,11 +13,11 @@
         You can contribute to, or report problems with,
         <a
           class="p-link--external"
-          href="https://bugs.launchpad.net/snappy"
+          href="https://bugs.launchpad.net/snapd"
         >snapd</a>,
         <a
           class="p-link--external"
-          href="https://github.com/snapcore/snapcraft/issues"
+          href="https://bugs.launchpad.net/snapcraft"
         >Snapcraft</a>,
         or
         <a


### PR DESCRIPTION
# Done

Fixes: https://github.com/canonical-docs/snappy-docs/issues/384

- Updated bug tracking links in footer

# QA

- Pull the branch
- `./run`
- Check the links are accurate: "The snapcraft tracker should be https://bugs.launchpad.net/snapcraft while the snapd one should be https://bugs.launchpad.net/snapd"