### PR TITLE
snapd install docs for Raspbian and nav index entry for elementary OS

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -17,8 +17,10 @@
             <ul>
               <li><a href="/core/install-arch-linux">Arch</a></li>
               <li><a href="/core/install-debian">Debian</a></li>
+              <li><a href="/core/install-elementary-os">elementary OS</a></li>
               <li><a href="/core/install-fedora">Fedora</a></li>
               <li><a href="/core/install-gentoo">Gentoo</a></li>
+              <li><a href="/core/install-raspbian">Raspbian</a></li>
               <li><a href="/core/install-linux-mint">Linux Mint</a></li>
               <li><a href="/core/install-manjaro">Manjaro</a></li>
               <li><a href="/core/install-oe-yocto">OpenEmbedded/Yocto</a></li>

--- a/core/install-raspbian.md
+++ b/core/install-raspbian.md
@@ -1,0 +1,21 @@
+---
+layout: base
+title: Install snapd on Raspian
+---
+
+If you installed Raspbian Lite you first need to enable the `contrib` and
+`non-free` repositories in `/etc/apt/sources.list.d/raspi.list`.
+
+You can install snapd on a Raspbian distribution via:
+
+```
+sudo apt update
+sudo apt install snapd
+sudo reboot
+```
+
+Afterwards everything is setup to get you started with snaps.
+
+## Next Steps
+
+ * [Using snaps](usage)

--- a/core/install.md
+++ b/core/install.md
@@ -20,4 +20,5 @@ instructions for each of these distributions.
  * [openSUSE](install-opensuse)
  * [OpenWrt](install-openwrt)
  * [Solus](install-solus)
+ * [Raspbian](install-raspbian)
  * [Ubuntu](install-ubuntu)


### PR DESCRIPTION
This pull request add snapd install docs for Raspbian and adds a missing navigation link for the recently added docs for elementary OS.