### PR TITLE
Interactive mode for Docker

### DIFF
--- a/build-snaps/build-on-lxd-docker.md
+++ b/build-snaps/build-on-lxd-docker.md
@@ -53,4 +53,4 @@ Next, make sure Docker is running:
 You're all set. Any time you want to build a snap, type the following commands to run snapcraft relative to the current directory:
 
        sudo docker pull snapcore/snapcraft
-       sudo docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
+       sudo docker run -it -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft


### PR DESCRIPTION
`-it` (interactive mode) is needed for login, which is needed for push