### PR TITLE
Remove 'My snaps' link from navigation.

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -58,7 +58,6 @@
                     <ul>
                         <li><a href="https://snapcraft.io/store/">Store</a></li>
                         <li><a href="https://build.snapcraft.io">Build</a></li>
-                        <li><a class="external" href="https://dashboard.snapcraft.io/snaps">My snaps</a></li>
                         <li class='active'><a href="/">Docs</a></li>
                         <li><a href="https://forum.snapcraft.io/categories">Forum</a></li>
                     </ul>


### PR DESCRIPTION
The link causes a lot of people to sign up for a developer account, without knowing they're doing so.

Fixes https://github.com/canonical-docs/snappy-docs/issues/376