### PR TITLE
build-on-lxd-docker: Be more space-proof

### DIFF
--- a/build-snaps/build-on-lxd-docker.md
+++ b/build-snaps/build-on-lxd-docker.md
@@ -53,4 +53,4 @@ Next, make sure Docker is running:
 You're all set. Any time you want to build a snap, type the following commands to run snapcraft relative to the current directory:
 
        sudo docker pull snapcore/snapcraft
-       sudo docker run -it -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
+       sudo docker run -it -v "$PWD:$PWD" -w "$PWD" snapcore/snapcraft snapcraft


### PR DESCRIPTION
The current command will break if the working directory contains spaces, like: `/home/林博仁/工作空間/第三方專案/Poedit - Gettext translations editor for OS X, Windows and Unix`.

This patch properly quotes the problematic parameter expansions with double quotes.

Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>