### PR TITLE
Prevent clobbering of primary user

### DIFF
--- a/build-snaps/get-started-snapcraft.md
+++ b/build-snaps/get-started-snapcraft.md
@@ -58,7 +58,7 @@ Configuration of the LXD defaults can be done via the `init` option. Typically a
 
 LXD requires that your user is in the lxd group. 
 
-`sudo usermod -g lxd ${USER}`
+`sudo usermod -aG lxd ${USER}`
 
 Logout and back in for the group change to take effect.
 


### PR DESCRIPTION
Replace the example command which overrides the user's primary group with the lxd group with a command that only adds lxd to the user's list of secondary groups.

Fixes #408 