### PR TITLE
Add user to group before init, to avoid error

### DIFF
--- a/build-snaps/get-started-snapcraft.md
+++ b/build-snaps/get-started-snapcraft.md
@@ -52,15 +52,16 @@ LXD installation on Ubuntu is quite straightforward:
 
 `snap install lxd`
 
+LXD requires that your user is in the lxd group. 
+
+```
+sudo usermod -g lxd ${USER}
+newgrp lxd
+```
+
 Configuration of the LXD defaults can be done via the `init` option. Typically accepting the default prompts is sufficient to get a working LXD configuration, usable by snapcraft on the same host:
 
 `sudo lxd init`
-
-LXD requires that your user is in the lxd group. 
-
-`sudo usermod -aG lxd ${USER}`
-
-Logout and back in for the group change to take effect.
 
 Test that LXD (and the lxc client) are correctly installed by starting a container:
 


### PR DESCRIPTION
The user [must be in the `lxd` group before `sudo lxd init` is run](https://bugs.launchpad.net/ubuntu/+source/lxd/+bug/1767469), for some reason (otherwise you get `Error: Failed to connect to local LXD: Get http://unix.socket/1.0: dial unix /var/snap/lxd/common/lxd/unix.socket: connect: no such file or directory`) - So move the instructions to add to group above that command.

I've also used the simpler `newgrp lxd` command, rather than asking the user to log out and back in.