### PR TITLE
Add Pop!_OS Instructions

### DIFF
--- a/core/install-pop-os.md
+++ b/core/install-pop-os.md
@@ -1,0 +1,17 @@
+---
+layout: base
+title: Install snapd on Pop!_OS
+---
+
+Pop!\_OS does not include `snapd` by default, so you need to install it from the
+repositories manually. You can do so by using the terminal:
+
+```
+sudo apt update
+sudo apt install snapd
+```
+
+## Next Steps
+
+ * [Using snaps](usage)
+

--- a/core/install.md
+++ b/core/install.md
@@ -19,6 +19,7 @@ instructions for each of these distributions.
  * [OpenEmbedded/Yocto](install-oe-yocto)
  * [openSUSE](install-opensuse)
  * [OpenWrt](install-openwrt)
+ * [Pop!\_OS](install-pop-os)
  * [Solus](install-solus)
  * [Raspbian](install-raspbian)
  * [Ubuntu](install-ubuntu)


### PR DESCRIPTION
Fixes #395. Note the `\` in Markdown; not escaping the underscore causes weird italics in markdown previewers like Atom and GitHub's web UI. It's harmless, but a minor annoyance.