### PR TITLE
Improve directions for "Name" field of LP snaps

### DIFF
--- a/build-snaps/ci-integration.md
+++ b/build-snaps/ci-integration.md
@@ -58,7 +58,7 @@ Finally, tell Launchpad to build and publish snaps for this repository:
 1. Type the name of your application in the "Snap name" field, then click on the "Register and proceed to upload" button
 1. Close this tab and return to the branch page on Launchpad
 1. Under the "Related snap packages" heading, click "Create snap package"
-1. In the "Name" field, enter the same name you used on the snap name registration page
+1. In the "Name" field, enter a name for the Launchpad snap recipe (if in doubt, use the same name you used on the snap name registration page)
 1. Under "Processors", select any hardware architectures you wish to build snaps for
 1. Check the box for "Automatically build when branch changes"
 1. Check the box for "Automatically upload to store"


### PR DESCRIPTION
I recently had a user turn up very confused because the docs website
said (or at least strongly implied) that this field has to be the name
of the snap; but they were trying to create two snap recipes for
different git branches that uploaded to different tracks in the store,
in which case a blanket "use the same name as the name of the snap"
instruction doesn't work.

These are getting-started instructions, so I don't want to overload them
with detail that many people won't need, but I've tweaked the wording to
try to indicate that the name of the snap is a good default but you can
use something else if need be.