### PR TITLE
Fix video aspect ratio

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -135,20 +135,6 @@
                                 item.addEventListener('click', expandCollapse);
                             }
                         }
-
-                        // Detect window resize event and adapt videos to it
-                        function resizeVideo() {
-                            var embeddedVideos = document.querySelectorAll("iframe.video-embed");
-
-                            embeddedVideos.forEach( function(embed) {
-                                var newVideoHeight = embed.offsetWidth*9/16;
-                                embed.height = Math.round(newVideoHeight);
-                            });
-                            
-                        }
-
-                        window.addEventListener('resize', resizeVideo);
-
                     </script>
                 </nav>
                 <main class="documentation__content">
@@ -161,5 +147,22 @@
         <footer class="footer-wrapper">
             {% include footer-legal.html %}
         </footer>
+
+        <script>
+
+            // Detect window resize event and adapt videos to it
+            function resizeVideo() {
+                var embeddedVideos = document.querySelectorAll("iframe.video-embed");
+
+                embeddedVideos.forEach( function(embed) {
+                    var newVideoHeight = embed.offsetWidth*9/16;
+                    embed.height = Math.round(newVideoHeight);
+                });
+                
+            }
+
+            window.addEventListener('resize', resizeVideo);
+
+        </script>
     </body>
 </html>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -135,6 +135,20 @@
                                 item.addEventListener('click', expandCollapse);
                             }
                         }
+
+                        // Detect window resize event and adapt videos to it
+                        function resizeVideo() {
+                            var embeddedVideos = document.querySelectorAll("iframe.video-embed");
+
+                            embeddedVideos.forEach( function(embed) {
+                                var newVideoHeight = embed.offsetWidth*9/16;
+                                embed.height = Math.round(newVideoHeight);
+                            });
+                            
+                        }
+
+                        window.addEventListener('resize', resizeVideo);
+
                     </script>
                 </nav>
                 <main class="documentation__content">

--- a/_sass/_documentation.scss
+++ b/_sass/_documentation.scss
@@ -274,6 +274,12 @@ $color-focus: #9d9c9a;
     iframe {
       margin: .25em 0 1em 0;
       width: 100%;
+      max-width: 720px;
+      max-height: 405px;
+      
+      @media only screen and (max-width: $breakpoint-medium) {
+        max-height:auto;
+      }
     }
 
     dl {

--- a/build-snaps/index.md
+++ b/build-snaps/index.md
@@ -3,7 +3,7 @@ layout: base
 title: Build snaps
 ---
 
-<iframe height="450" src="https://www.youtube.com/embed/ZsUV9xnrkTA?rel=0&showinfo=0" allowfullscreen></iframe>
+<iframe width="720" height="405" class="video-embed" src="https://www.youtube.com/embed/ZsUV9xnrkTA?rel=0&showinfo=0" allowfullscreen></iframe>
 
 ## Get Started with Snapcraft
 

--- a/build-snaps/node.md
+++ b/build-snaps/node.md
@@ -3,7 +3,7 @@ layout: base
 title: Node
 ---
 
-<iframe height="450" src="https://www.youtube.com/embed/S3YvRALc2C0?rel=0&showinfo=0" allowfullscreen></iframe>
+<iframe width="720" height="405" class="video-embed" src="https://www.youtube.com/embed/S3YvRALc2C0?rel=0&showinfo=0" allowfullscreen></iframe>
 
 Node has rich tools for packaging, distributing and sandboxing applications. Snapcraft builds on top of these familiar tools such as `npm` and `yarn` to create snaps.
 

--- a/reference/channels.md
+++ b/reference/channels.md
@@ -39,7 +39,7 @@ Tracks allow you to publish different series of your software (1.0, 2.0, etc.) a
 
 ### Overview
 
-<iframe height="450" src="https://www.youtube.com/embed/S3xRFnbVkvs?rel=0&showinfo=0" allowfullscreen></iframe>
+<iframe width="720" height="405" src="https://www.youtube.com/embed/S3xRFnbVkvs?rel=0&showinfo=0" allowfullscreen></iframe>
 
 * By default, snaps are published to a track called `latest`. This is also the default for users when they install a snap, for example `snap install my-app --beta` implies `--channel=latest/beta`.
 * Users do not get automatically moved between tracks. It is the user's decision to not install snaps from the `latest` track, or to move back to it or any other track. Installing a snap from a track is done with the `--channel=<track>/<risk level>` flag.
@@ -51,7 +51,7 @@ There are four risk levels available for snaps, that denote the stability of rev
 
 ### Overview
 
-<iframe height="450" src="https://www.youtube.com/embed/-3b9qkl9Z_k?rel=0&showinfo=0" allowfullscreen></iframe>
+<iframe width="720" height="405" class="video-embed" src="https://www.youtube.com/embed/-3b9qkl9Z_k?rel=0&showinfo=0" allowfullscreen></iframe>
 
 * Note that in developer discussions and some documentation, the "risk level" is often referred as the "channel", since most snaps only use the default track and no branches.
 * By default, the `snap install` command installs snaps from the `stable` level.

--- a/snaps/index.md
+++ b/snaps/index.md
@@ -3,7 +3,7 @@ layout: base
 title: Snaps
 ---
 
-<iframe height="450" src="https://www.youtube.com/embed/DLxqdf89hRo?rel=0&showinfo=0" allowfullscreen></iframe>
+<iframe width="720" height="405" class="video-embed" src="https://www.youtube.com/embed/DLxqdf89hRo?rel=0&showinfo=0" allowfullscreen></iframe>
 
 This section provides you with details about the content and structure of a snap. There is sufficient information in this section to enable you to create your own snap files manually. That said, this information is primarily meant as background to help with your understanding of how Snapcraft builds snaps.
 


### PR DESCRIPTION
Fixes #425 
Make embeded videos great again

## QA
* Pull the branch
* `./run`
* Visit https://0.0.0.0/8202
* Check videos on [docs homepage](http://0.0.0.0:8202/snaps/), [node](http://0.0.0.0:8202/build-snaps/node), [build snaps](http://0.0.0.0:8202/build-snaps/), [channels](http://0.0.0.0:8202/reference/channels) adapt on a 16:9 aspect ratio on mobile (full width) and desktop (max-width: 720px)