### PR TITLE
Fix socket's documentation

### DIFF
--- a/build-snaps/syntax.md
+++ b/build-snaps/syntax.md
@@ -384,7 +384,8 @@ The socket abstract name or socket path. Valid formats are: `<port>`, `[::]:<por
           plugs: [home, network-bind]
           daemon: simple
           sockets:
-            listen-stream: 8080
+            my-socket-name:
+              listen-stream: 8080
 
 ### socket-mode
 
@@ -399,8 +400,9 @@ For Unix sockets, the file permission (e.g. `0644`).
           plugs: [home, network-bind]
           daemon: simple
           sockets:
-            listen-stream: $SNAP_DATA/foo_data
-            socket-mode: 0644
+            my-socket-name:
+              listen-stream: $SNAP_DATA/foo_data
+              socket-mode: 0644
 
 ### parts
 


### PR DESCRIPTION
According to snapcraft's schema
(https://github.com/snapcore/snapcraft/blob/master/schema/snapcraft.yaml#L323-L349),
`sockets` take an object with a name. Not directly a `listen-stream`.