### PR TITLE
Add IoT to navigation

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -58,6 +58,7 @@
                     <ul>
                         <li><a href="https://snapcraft.io/store/">Store</a></li>
                         <li><a href="https://snapcraft.io/blog/">Blog</a></li>
+                        <li><a href="https://snapcraft.io/iot">IoT</a></li>
                         <li><a href="https://snapcraft.io/build">Build</a></li>
                         <li class='active'><a href="/">Docs</a></li>
                         <li><a href="https://forum.snapcraft.io/categories" class="external">Forum</a></li>


### PR DESCRIPTION
Added IoT to the navigation in preparation for https://github.com/canonical-websites/snapcraft.io/pull/994

# QA

- Pull the branch
- `./run`
- Visit any page, see the IoT link in the header