### PR TITLE
Highlight selected navigation item

### DIFF
--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -82,7 +82,7 @@
             }
             
             &.active {
-              box-shadow: 0 -3px 0 #e95420 inset;
+              box-shadow: 0 -3px 0 rgba(250,99,64,1) inset;
             }
           }
 

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -80,6 +80,10 @@
             &:hover {
               background-color: $navigation-hover-color;
             }
+            
+            &.active {
+              box-shadow: 0 -3px 0 #e95420 inset;
+            }
           }
 
           // sass-lint:disable nesting-depth

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -82,7 +82,7 @@
             }
             
             &.active {
-              box-shadow: 0 -3px 0 rgba(250,99,64,1) inset;
+              box-shadow: 0 -3px 0 rgba(250, 99, 64, 1) inset;
             }
           }
 


### PR DESCRIPTION
Fixes [snapcraft.io#591](https://github.com/canonical-websites/snapcraft.io/issues/591)

## QA

1. Pull the branch or demo
2. Check the Docs navigation item is highlighted across the whole site

**Notes:** We should merge this PR once the other sites also have the same functionality