### PR TITLE
Fix non-sensical sentence in philosopy page

### DIFF
--- a/snaps/philosophy.md
+++ b/snaps/philosophy.md
@@ -43,7 +43,8 @@ your data are always compatible with your code.
 So, use `$SNAP_USER_DATA` for user data. If you have global configuration that should be readable by multiple users,
 read and write to `$SNAP_DATA`. Remember that this last path is only writable by the root user though.
 
-You can have your wrapper script using the same environment variable technique than described on the first stanza.
+Your wrapper script can use the same environment variable technique
+described in the [Relocatable Code](#relocatable-code) section.
 Another strategy is to unconditionally `cd` to `$SNAP_USER_DATA`.
 
 ## Common vs versioned path.


### PR DESCRIPTION
As described in https://github.com/canonical-docs/snappy-docs/issues/156 and https://github.com/canonical-webteam-archive/snapcraft.io-static-pages/issues/345, the current statement (below) doesn't make any sense:
> You can have your wrapper script using the same environment variable technique than described on the first stenza

I tried to make sense out of it to the best of my knowledge and hopefully fixed it.
If this PR looks right, it closes https://github.com/canonical-docs/snappy-docs/issues/156
