### PR TITLE
Fix default PATH value

### DIFF
--- a/reference/env.md
+++ b/reference/env.md
@@ -107,4 +107,4 @@ Typical value: `/home/zyga/snap/hello-world/27`
 
 This environment variable is re-written by snapd so that it is consistent with the view of the filesystem presented to snap applications.
 
-The value is always: `/usr/sbin:/usr/bin:/sbin:/bin:/usr/games`
+The value is always: `$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH`


### PR DESCRIPTION
The default PATH value in the docs doesn't match the one overwritten in snapd 2.35: "$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"

This patch assumes the prefixing `$SNAP` is missing from all components and `$SNAP/usr/games` doesn't really set as claimed in the docs.

Fixes #441.

Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>